### PR TITLE
Convert a chunk to a string.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,5 +31,5 @@ function fromWritable (stream) {
 }
 
 function bufferize (chunk) {
-  return Buffer.isBuffer(chunk) ? chunk : new Buffer(chunk.toString())
+  return Buffer.isBuffer(chunk) ? chunk : new Buffer([chunk])
 }

--- a/index.js
+++ b/index.js
@@ -31,5 +31,5 @@ function fromWritable (stream) {
 }
 
 function bufferize (chunk) {
-  return Buffer.isBuffer(chunk) ? chunk : new Buffer(chunk)
+  return Buffer.isBuffer(chunk) ? chunk : new Buffer(chunk.toString())
 }

--- a/index.js
+++ b/index.js
@@ -31,5 +31,6 @@ function fromWritable (stream) {
 }
 
 function bufferize (chunk) {
-  return Buffer.isBuffer(chunk) ? chunk : new Buffer([chunk])
+  var newBuffer = typeof chunk === 'object' ? new Buffer([chunk]) : new Buffer(chunk)
+  return Buffer.isBuffer(chunk) ? chunk : newBuffer
 }


### PR DESCRIPTION
In latest node versions it's possible that chunk is an object when using this module with gulp streams as vinyl files return objects. Because of this the module breaks, as a sanity check we should be converting the chunk to a string to ensure a buffer can be created from it.

This issue can be replicated by creating a gulp task which creates an array of promises converted from gulp streams. This appears to be broken in node 5.x, not sure when it became an issue though. Our build process previously ran on 0.13.x

```javascript
var sources = ['./folder/*.js', './folder/*.css']; 

gulp.task('test', function (done) {
  var promises = sources.map(function (source) {
    return streamToPromise(gulp.src([source]));
  });

  Promise.all(promises).then(function () {
    done();
  });
});
```