### PR TITLE
Update stream-to-array

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/bendrucker/stream-to-promise",
   "dependencies": {
     "bluebird": "~3.0.6",
-    "stream-to-array": "~2.2.0"
+    "stream-to-array": "~2.3.0"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
`stream-to-array#2.2.0` shows a deprecation warning about one of its dependencies.