### PR TITLE
Use `any-promise` instead of `bluebird`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var toArray = require('stream-to-array')
-var Promise = require('bluebird')
+var Promise = require('any-promise')
 
 module.exports = streamToPromise
 


### PR DESCRIPTION
It appears that `any-promise` was added to `package.json` and intended to be used as the `Promise` implementation, but `bluebird` was left in `index.js`. Swapped. Working.