### PR TITLE
Separate --save and --save-dev installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ stream-to-promise [![Build Status](https://travis-ci.org/bendrucker/stream-to-pr
 ## Installing
 
 ```sh
-$ npm install --save[-dev] stream-to-promise
+$ npm install --save stream-to-promise
+$ npm install --save-dev stream-to-promise
 ```
 
 ## Examples


### PR DESCRIPTION
Putting `npm install --save[-dev] stream-to-promise` in the readme makes it difficult to copy-past into the command line, something that I do all the time and I suspect is very common. Separating out these two lines would be greatly appreciated.